### PR TITLE
Wip edit image buttons

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -9,7 +9,7 @@ Changes in progress
 - Updated Mailer library
 - Fixed list of lastest created blogs being always empty
 - Slideshare: Improved catalan language files
-
+- Activate editting image buttons on freshy 2 theme
 
 15.04.16
 ---------------------------------------------------------------------------------------

--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -9,7 +9,7 @@ Changes in progress
 - Updated Mailer library
 - Fixed list of lastest created blogs being always empty
 - Slideshare: Improved catalan language files
-- Activate editting image buttons on freshy 2 theme
+- Fixed missing image buttons for edition on freshy 2 theme
 
 15.04.16
 ---------------------------------------------------------------------------------------

--- a/src/wp-content/themes/freshy2/functions.php
+++ b/src/wp-content/themes/freshy2/functions.php
@@ -19,18 +19,20 @@ if ( function_exists('register_sidebar') ) {
 }
 
 add_action('widgets_init', 'freshy_widgets_init');
-//XTEC ********** ELIMINAT - This code calls a function
-//2015.05.19
+
+// XTEC ********** ELIMINAT - Loading of CSS that hides buttons when editing images
+// 2015.05.19 @jcaballero
 /*
 add_filter("mce_css", "freshy_editor_mce_css", 0);
 */
 //*********FI
+
 add_filter("mce_buttons", "freshy_editor_mce_buttons", 0);
 
 if (!class_exists('Nice_theme')) add_action('wp_head','freshy_head');
 
-//XTEC ********** ELIMINAT - This code loads CSS that hides buttons when editing images
-//2015.05.19
+// XTEC ********** ELIMINAT - Loading of CSS that hides buttons when editing images
+// 2015.05.19 @jcaballero
 /*
 function freshy_editor_mce_css($stylesheets) {
 	$stylesheets = get_bloginfo('stylesheet_directory').'/content.css';
@@ -38,6 +40,7 @@ function freshy_editor_mce_css($stylesheets) {
 }
 */
 //**********FI
+
 function freshy_editor_mce_buttons($buttons) {
 	$buttons[] = "styleselect";
 	return $buttons;

--- a/src/wp-content/themes/freshy2/functions.php
+++ b/src/wp-content/themes/freshy2/functions.php
@@ -19,16 +19,25 @@ if ( function_exists('register_sidebar') ) {
 }
 
 add_action('widgets_init', 'freshy_widgets_init');
+//XTEC ********** ELIMINAT - This code calls a function
+//2015.05.19
+/*
 add_filter("mce_css", "freshy_editor_mce_css", 0);
+*/
+//*********FI
 add_filter("mce_buttons", "freshy_editor_mce_buttons", 0);
 
 if (!class_exists('Nice_theme')) add_action('wp_head','freshy_head');
 
+//XTEC ********** ELIMINAT - This code loads CSS that hides buttons when editing images
+//2015.05.19
+/*
 function freshy_editor_mce_css($stylesheets) {
 	$stylesheets = get_bloginfo('stylesheet_directory').'/content.css';
 	return $stylesheets;
 }
-
+*/
+//**********FI
 function freshy_editor_mce_buttons($buttons) {
 	$buttons[] = "styleselect";
 	return $buttons;


### PR DESCRIPTION
per provar que ja es poden editar imatges amb el theme freshy 2,  cal  establir aquest tema, crear l'article, posar-li una imatge i haurien d'apareixer les icones d'edició