### PR TITLE
Bug fixes to choose table schema in extension Multisite Clone Duplicator

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -8,6 +8,7 @@ Changes in progress
 - Synced code with Nodes that have no effect in XTECBlocs
 - wp-recaptcha: Added default configuration for Nodes when activating plugin (Trello #926)
 - Blocked access to install.php (Trello #521)
+- Clone Duplicator: Fixed incorrect selection of data base (Trello #609) 
 
 
 

--- a/src/wp-content/plugins/multisite-clone-duplicator/lib/data.php
+++ b/src/wp-content/plugins/multisite-clone-duplicator/lib/data.php
@@ -48,7 +48,15 @@ if( !class_exists( 'MUCD_Data' ) ) {
             $from_site_prefix_like = $wpdb->esc_like($from_site_prefix);
 
             // SCHEMA - TO FIX for HyperDB
+            // XTEC ************ MODIFICAT - Add support for HyperDB
+            // 2015.10.28 @dgras
+            $sql_query = $wpdb->prepare('SELECT DISTINCT TABLE_SCHEMA FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME LIKE \'%s\'', $from_site_prefix_like."%");
+            $schema = MUCD_Data::do_sql_query($sql_query, 'var');
+            //************ ORIGINAL
+            /*
             $schema = DB_NAME;
+            */
+            //************ FI
 
             // Get sources Tables
             if($from_site_id == MUCD_PRIMARY_SITE_ID) {


### PR DESCRIPTION
L'esquema de la taula per fer el clone l'agafava d'una constant predefinida que no variava. La realitat és que l'esquema depèn d'on es trobi el bloc que es copia i això fa que l'esquema sigui dinàmic.

Amb aquesta actualització s'aconsegueix obtenir l'esquema corresponent al bloc que es vol clonar.

Aquesta actualització es comprova clonant un blog i veient que és idèntic al clonat.