### PR TITLE
Lock access to install files if exists or not database

### DIFF
--- a/src/wp-admin/install.php
+++ b/src/wp-admin/install.php
@@ -153,35 +153,31 @@ function display_setup_form( $error = null ) {
 <?php
 } // end display_setup_form()
 
+//XTEC ************ AFEGIT - Block access to install functions. Show "site off" message instead.
+//2015.08.05 @nacho
+//2015.11.06 @pferre22
+if ( !isset($agora['server']['enviroment']) || ($agora['server']['enviroment'] != 'LOCAL' && $agora['server']['enviroment'] != 'DES') ) {
+	$siteoff_file = '../siteoff.html';
+	if (file_exists($siteoff_file)) {
+		include_once($siteoff_file);
+	} else {
+		echo '<html><body>';
+		echo '<div style="text-align:center; font-size:large; border-width:1px; '.
+				'    border-color:#CCC; border-style:solid; border-radius: 20px; border-collapse: collapse; '.
+				'    -moz-border-radius:20px; padding:15px; margin: 200px 100px 0px 100px;">';
+		echo '<h2>Servei no disponible</h2>';
+		echo '<p>El servei a qu&egrave; intenteu accedir est&agrave; temporalment fora de servei. Estem treballant per solucionar el problema al m&eacute;s aviat possible. Si us plau proveu d\'accedir-hi m&eacute;s tard.</p>';
+		echo '<p style="font-size:medium">Disculpeu les mol&egrave;sties.</p>';
+		echo '</div></body></html>';
+	}
+	exit(0);
+}
+//************ FI
+
 // Let's check to make sure WP isn't already installed.
 if ( is_blog_installed() ) {
-	//XTEC ************ MODIFICAT - Block access to install functions. Show "site off" message instead.
-	//2015.08.05 @nacho
-	if ( !isset($agora['server']['enviroment']) || ($agora['server']['enviroment'] != 'LOCAL' && $agora['server']['enviroment'] != 'DES') ) {
-		$siteoff_file = '../siteoff.html';
-		if (file_exists($siteoff_file)) {
-			include_once($siteoff_file);
-		} else {
-			echo '<html><body>';
-			echo '<div style="text-align:center; font-size:large; border-width:1px; '.
-					'    border-color:#CCC; border-style:solid; border-radius: 20px; border-collapse: collapse; '.
-					'    -moz-border-radius:20px; padding:15px; margin: 200px 100px 0px 100px;">';
-			echo '<h2>Servei no disponible</h2>';
-			echo '<p>El servei a qu&egrave; intenteu accedir est&agrave; temporalment fora de servei. Estem treballant per solucionar el problema al m&eacute;s aviat possible. Si us plau proveu d\'accedir-hi m&eacute;s tard.</p>';
-			echo '<p style="font-size:medium">Disculpeu les mol&egrave;sties.</p>';
-			echo '</div></body></html>';
-		}
-		exit(0);
-	}else {
-		display_header();
-		die( '<h1>' . __( 'Already Installed' ) . '</h1><p>' . __( 'You appear to have already installed WordPress. To reinstall please clear your old database tables first.' ) . '</p><p class="step"><a href="../wp-login.php" class="button button-large">' . __( 'Log In' ) . '</a></p></body></html>' );
-	}
-	//************ ORIGINAL
-	/*
 	display_header();
 	die( '<h1>' . __( 'Already Installed' ) . '</h1><p>' . __( 'You appear to have already installed WordPress. To reinstall please clear your old database tables first.' ) . '</p><p class="step"><a href="../wp-login.php" class="button button-large">' . __( 'Log In' ) . '</a></p></body></html>' );
-	*/
-	//************ FI
 }
 
 global $wp_version, $required_php_version, $required_mysql_version;


### PR DESCRIPTION
Bloqueja la instal·lació del Wordpress (Trello #521).
Per provar el seu funcionament, cal canviar l'entorn al fitxer de configuració (ha de ser diferent a LOCAL o DES) i accedir a http://agora/blocs/wp-admin/install.php. Tot seguit ha d'aparèixer un missatge que impedeix realitzar la instal·lació.

Per provar que a la MV segueix sense bloquejar cal afegir:
$agora['server']['enviroment'] = 'LOCAL';
al wp-config.php