### PR TITLE
Fix default comment status to new posts

### DIFF
--- a/src/wp-content/mu-plugins/xtecblocs-functions.php
+++ b/src/wp-content/mu-plugins/xtecblocs-functions.php
@@ -58,3 +58,17 @@ add_filter('wp_insert_post_data', 'fix_spanish_scribd_oembed', 10, 2);
 * @author sarjona
 */
 remove_filter('force_filtered_html_on_import', '__return_true');
+
+/**
+* When create a new post, we check default comment status value and assign it.
+*
+* @author xaviernietosanchez
+*/
+function my_project_updated_send_email( $data, $postarr ) {
+	if( $data['post_status'] == 'auto-draft' && $data['post_title'] == 'Esborrany automàtic' ){
+		$data['comment_status'] = get_default_comment_status();
+	}
+
+	return $data;
+}
+add_action( 'wp_insert_post_data', 'my_project_updated_send_email', 10, 2 );


### PR DESCRIPTION
Fer que quan es crea un nou post (exemple: article) s'apliqui al paràmetre el valor seleccionat a opcions|debats al input "default-comment-status", per que als nous posts es reflecteixi la opció seleccionada.

Proves:

- Cal modificar el paràmetre a " opcions | debats | Permet a la gent fer comentaris als articles nous. "
- Crear un article nou i observar que el checkbox de "Permet comentaris" correspon a la opció seleccionada a les opcions.
- Desar l'article canviant el checkbox i observar con es guarda la opció aplicada al article, sense tindre en compte la opció per defecte.