### PR TITLE
Customize theme to correct calendar visualizations

### DIFF
--- a/src/wp-content/themes/classic-chalkboard/style.css
+++ b/src/wp-content/themes/classic-chalkboard/style.css
@@ -1164,3 +1164,22 @@ ul.children .comment-author cite.fn {
 		padding-left: 50px;
 	}
 }
+
+/* XTEC ************ AFEGIT - Custom style to google calendar */
+/* 2017.02.09 @xaviernietosanchez */
+.simcal-week-day{
+	background-color: transparent !important;
+}
+
+.simcal-event-details{
+	color: #666666 !important;
+}
+
+.simcal-event-details a{
+	color: #1E73BE !important;
+}
+
+.simcal-events-dots b{
+	color: #ffffff !important;
+}
+/* *********** FI */

--- a/src/wp-content/themes/twentyfourteen/style.css
+++ b/src/wp-content/themes/twentyfourteen/style.css
@@ -4320,3 +4320,18 @@ a.post-thumbnail:hover {
 		line-height: 36px;
 	}
 }
+
+/* XTEC ************ AFEGIT - Custom style to google calendar */
+/* 2017.02.09 @xaviernietosanchez */
+.simcal-nav-button, .simcal-events-dots b{
+	color: #AFAF8F !important;
+}
+
+.simcal-day-label{
+	white-space: nowrap !important;
+}
+
+.simcal-week-day{
+	background-color: transparent !important;
+}
+/* ************ FI */


### PR DESCRIPTION
Afegit estils al tema classic-chalkboard i al tweenty-fourteen per adaptar la visualització del calendari.

Proves:

- Activar a un bloc els themes classic-chalkboard i el theme tweenty fourteen.
- Comprovar que la visualització del calendari al giny com a la pàgina és correcta.