### PR TITLE
Customize theme to correct calendar visualizations

### DIFF
--- a/src/wp-content/themes/classic-chalkboard/style.css
+++ b/src/wp-content/themes/classic-chalkboard/style.css
@@ -1164,3 +1164,27 @@ ul.children .comment-author cite.fn {
 		padding-left: 50px;
 	}
 }
+
+/* XTEC ************ AFEGIT - Custom style to google calendar */
+/* 2017.02.09 @xaviernietosanchez */
+.simcal-week-day{
+	background-color: transparent !important;
+}
+
+.simcal-event-details{
+	color: #666666 !important;
+}
+
+.simcal-event-details a{
+	color: #1E73BE !important;
+}
+
+.simcal-events-dots b{
+	color: #ffffff !important;
+}
+
+.widget-area .simcal-week-day{
+	white-space: nowrap !important;
+	font-size: 0.8em;
+}
+/* *********** FI */

--- a/src/wp-content/themes/twentyfourteen/style.css
+++ b/src/wp-content/themes/twentyfourteen/style.css
@@ -4320,3 +4320,23 @@ a.post-thumbnail:hover {
 		line-height: 36px;
 	}
 }
+
+/* XTEC ************ AFEGIT - Custom style to google calendar */
+/* 2017.02.09 @xaviernietosanchez */
+.simcal-nav-button, .simcal-events-dots b{
+	color: #AFAF8F !important;
+}
+
+.simcal-day-label{
+	white-space: nowrap !important;
+}
+
+.simcal-week-day{
+	background-color: transparent !important;
+}
+
+.widget .simcal-week-day{
+	white-space: nowrap !important;
+	font-size: 0.8em;
+}
+/* ************ FI */

--- a/src/wp-content/themes/twentythirteen/style.css
+++ b/src/wp-content/themes/twentythirteen/style.css
@@ -3226,3 +3226,23 @@ footer.entry-meta {
 		color: #333;
 	}
 }
+
+/* XTEC ************ AFEGIT - Custom style to google calendar */
+/* 2017.03.08 @xaviernietosanchez */
+.simcal-week-day{
+	background-color: transparent !important;
+}
+
+.simcal-events-dots b{
+	color: #fff !important;
+}
+
+.simcal-icon-right, .simcal-icon-left{
+	color: #fff !important;
+}
+
+.widget .simcal-week-day{
+	white-space: nowrap !important;
+	font-size: 0.8em;
+}
+/* ************ FI */


### PR DESCRIPTION
Afegir personalització per la correcta visualització del simple calendar sota els themes twenty fourteen, twenty thirteen i classic Chalkboard.

Per provar:

- Cal afegir un calendari com pàgina i com a widget.
- Comprovar que la seva visualització es correcta, en català, castellà i angles.